### PR TITLE
Initialize core_net types safely

### DIFF
--- a/src/types/url.rs
+++ b/src/types/url.rs
@@ -103,13 +103,13 @@ impl Url {
                     }
                 }
                 url::Host::Ipv4(addr) => {
-                    let addrx: core_net::Ipv4Addr = unsafe { std::mem::transmute(addr) };
+                    let addrx = core_net::Ipv4Addr::from(addr.octets());
                     if !addrx.is_global() {
                         return Err(Error::InvalidUrlHost(format!("{host}")));
                     }
                 }
                 url::Host::Ipv6(addr) => {
-                    let addrx: core_net::Ipv6Addr = unsafe { std::mem::transmute(addr) };
+                    let addrx = core_net::Ipv6Addr::from(addr.octets());
                     if !addrx.is_global() {
                         return Err(Error::InvalidUrlHost(format!("{host}")));
                     }


### PR DESCRIPTION
This removes the assumption that the two types have the same memory layout, which could lead to invalid memory access if it changes in a future version of rust's standard library.

See https://github.com/mikedilger/core-net/issues/1